### PR TITLE
Add rule to enforce dependencies for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Forbid the use of multiline values to expansions.update.
 Enforce that if a task contains a specified function, any dependencies required for
 that function are included as dependencies of that task.
 
+Since dependencies are defined at the task level, the dependency list provided in the
+configuration takes funcs as the key and a list of task names as the value.
+
 *Solution*: Add the required dependency to the task.
 
 #### Configuration

--- a/README.md
+++ b/README.md
@@ -67,3 +67,23 @@ Forbid the use of multiline values to expansions.update.
 
 *Solution*: Don't do that. If you absolutely must, see the `files` param in the
 [documentation](https://github.com/evergreen-ci/evergreen/wiki/Project-Commands#expansions-update).
+
+### dependency-for-func
+Enforce that if a task contains a specified function, any dependencies required for
+that function are included as dependencies of that task.
+
+*Solution*: Add the required dependency to the task.
+
+#### Configuration
+
+Which dependencies should be enforced can be configured via the lint config files. The
+configuration should use the following format:
+
+```yaml
+rules:
+  - rule: dependency-for-func
+    dependencies:
+      func_name_0: [dependency_task_0, dependency_task_1]
+      func_name_1:
+        - dependency_task_2
+```

--- a/evergreen_lint/config.py
+++ b/evergreen_lint/config.py
@@ -113,6 +113,9 @@ rules:
     - rule: "required-expansions-write"
       # applicable shell script
       regex: .*\\/evergreen\\/.*\\.sh
+    # Enforce tasks that include specified functions include required dependencies
+    - rule: "dependency-for-func"
+      dependencies: {{}}
 """[
     1:-1
 ]  # <--- this strips the leading and trailing newlines from this HEREDOC

--- a/evergreen_lint/helpers.py
+++ b/evergreen_lint/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for iterating over the yaml dictionary."""
 import re
-from typing import Callable, Generator, List, Tuple, Union
+from typing import Callable, Generator, List, Tuple, Union, Set
 
 _CommandList = List[dict]
 _Commands = Union[dict, _CommandList]
@@ -274,3 +274,22 @@ def iterate_command_lists(yaml_dict: dict) -> Generator[Tuple[str, _Commands], N
     gen = _iterator(yaml_dict, _helper)
     for out in gen:
         yield out  # type: ignore
+
+
+def determine_dependencies_of_task_def(task_def: dict) -> Set[str]:
+    """
+    Determine the dependencies defined in the task definition.
+
+    Dependencies can be listed as strings or dictionaries, so we need to check both.
+
+    :param task_def: Task definition to check.
+    :return: Set of all dependencies found in task definition.
+    """
+    depends_on = task_def.get("depends_on", [])
+    dependencies = set()
+    for d in depends_on:
+        if isinstance(d, dict):
+            dependencies.add(d["name"])
+        else:
+            dependencies.add(d)
+    return dependencies

--- a/evergreen_lint/rules.py
+++ b/evergreen_lint/rules.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set, Type
 
 import evergreen_lint.helpers as helpers
 from evergreen_lint.helpers import (
+    determine_dependencies_of_task_def,
     iterate_command_lists,
     iterate_commands,
     iterate_fn_calls_context,
@@ -451,6 +452,53 @@ class RequiredExpansionsWrite(Rule):
         return out
 
 
+class DependencyForFunc(Rule):
+    """
+    Define dependencies that are required if a function is used.
+
+    The configuration will look like:
+
+    ```
+    - rule: "dependency-for-func"
+      dependencies:
+        func_name: [dependency_0, depdendency_1]
+    ```
+
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "dependency-for-func"
+
+    @staticmethod
+    def defaults() -> dict:
+        return {"dependencies": {}}
+
+    def __call__(self, config: dict, yaml: dict) -> List[LintError]:
+        error_msg = (
+            "Missing dependency. The task '{task_name}' expects '{dependency}' to be "
+            "listed as a dependency due to the use of the '{function}' func."
+        )
+        failed_checks = []
+        dependency_map = config.get("dependencies", {})
+        for task_def in yaml.get("tasks"):
+            actual_dependencies = determine_dependencies_of_task_def(task_def)
+            funcs = [cmd["func"] for cmd in task_def.get("commands", []) if "func" in cmd]
+            for func in funcs:
+                expected_dependencies = dependency_map.get(func, [])
+                unmet_dependenices = [
+                    dep for dep in expected_dependencies if dep not in actual_dependencies
+                ]
+                failed_checks.extend(
+                    [
+                        error_msg.format(task_name=task_def["name"], dependency=dep, function=func)
+                        for dep in unmet_dependenices
+                    ]
+                )
+
+        return failed_checks
+
+
 RULES: Dict[str, Type[Rule]] = {
     "limit-keyval-inc": LimitKeyvalInc,
     "shell-exec-explicit-shell": ShellExecExplicitShell,
@@ -460,6 +508,7 @@ RULES: Dict[str, Type[Rule]] = {
     "no-multiline-expansions-update": NoMultilineExpansionsUpdate,
     "invalid-build-parameter": InvalidBuildParameter,
     "required-expansions-write": RequiredExpansionsWrite,
+    "dependency-for-func": DependencyForFunc,
 }
 # Thoughts on Writing Rules
 # - see .helpers for reliable iteration helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen-lint"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Richard Samuels <richard.samuels@mongodb.com>"]
 


### PR DESCRIPTION
Add a lint rule to enforce that any tasks that include a specified function should include certain dependencies.