### PR TITLE
DEVPROD-4967 Add variant tags linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,25 @@ rules:
         min_num_of_tags: 1
         max_num_of_tags: 1
 ```
+
+
+### enforce-tags-for-variants
+Enforce tags presence in variant definitions.
+
+#### Configuration
+
+Which variant tags should be enforced can be configured via the lint config files. The
+configuration should use the following format:
+
+```yaml
+rules:
+  - rule: "enforce-tags-for-variants"
+    tags:
+      # the rule will fail if the variant has matching configuration
+      # and is not tagged with the tag that matches tag_name
+      # and vice-versa
+      - tag_name: "required"
+        variant_config:
+          name_regex: ".*"
+          display_name_regex: "^!.+$"
+```

--- a/evergreen_lint/__init__.py
+++ b/evergreen_lint/__init__.py
@@ -1,3 +1,3 @@
 """I exist to appease the linter."""
 
-__version__ = "0.1.5"  # Duplicated in pyproject.toml.
+__version__ = "0.1.6"  # Duplicated in pyproject.toml.

--- a/evergreen_lint/config.py
+++ b/evergreen_lint/config.py
@@ -131,6 +131,10 @@ rules:
     # Enforce tasks must have tags
     - rule: "enforce-tags-for-tasks"
       tag_groups: {[]}
+
+    # Enforce variants must have tags
+    - rule: "enforce-tags-for-variants"
+      tags: {[]}
 """[
     1:-1
 ]  # <--- this strips the leading and trailing newlines from this HEREDOC

--- a/evergreen_lint/rules/__init__.py
+++ b/evergreen_lint/rules/__init__.py
@@ -12,6 +12,7 @@ from evergreen_lint.rules.commonsense import (
 )
 from evergreen_lint.rules.dependency_for_func import DependencyForFunc
 from evergreen_lint.rules.enforce_tags_for_tasks import EnforceTagsForTasks
+from evergreen_lint.rules.enforce_tags_for_variants import EnforceTagsForVariants
 from evergreen_lint.rules.invalid_build_parameter import InvalidBuildParameter
 from evergreen_lint.rules.required_expansions_write import RequiredExpansionsWrite
 from evergreen_lint.rules.tasks_for_variants import TasksForVariants
@@ -28,6 +29,7 @@ RULES: Dict[str, Type[Rule]] = {
     "dependency-for-func": DependencyForFunc,
     "tasks-for-variants": TasksForVariants,
     "enforce-tags-for-tasks": EnforceTagsForTasks,
+    "enforce-tags-for-variants": EnforceTagsForVariants,
 }
 # Thoughts on Writing Rules
 # - see .helpers for reliable iteration helpers

--- a/evergreen_lint/rules/enforce_tags_for_tasks.py
+++ b/evergreen_lint/rules/enforce_tags_for_tasks.py
@@ -76,7 +76,7 @@ class EnforceTagsForTasks(Rule):
         failed_checks = []
         rule_config = EnforceTagsForTasksConfig.from_config_dict(config)
 
-        for task_def in cast(List, yaml.get("tasks")):
+        for task_def in cast(List, yaml.get("tasks", [])):
             actual_tags = task_def.get("tags")
             actual_tags_set = set()
             if actual_tags is not None:

--- a/evergreen_lint/rules/enforce_tags_for_variants.py
+++ b/evergreen_lint/rules/enforce_tags_for_variants.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import re
+from typing import List, NamedTuple, Optional, cast
+
+from evergreen_lint.model import LintError, Rule
+
+
+class VariantConfig(NamedTuple):
+    name_regex: Optional[str] = None
+    display_name_regex: Optional[str] = None
+
+    def print(self, indent: int = 2) -> str:
+        output = ""
+
+        for key, value in self._asdict().items():
+            if value is not None:
+                output = f'{output}\n{" " * indent}{key}: "{value}"'
+
+        return output
+
+
+class TagConfig(NamedTuple):
+    tag_name: str
+    variant_config: VariantConfig
+
+
+class EnforceTagsForVariantsConfig(NamedTuple):
+    tags: List[TagConfig]
+
+    @classmethod
+    def from_config_dict(cls, config_dict) -> EnforceTagsForVariantsConfig:
+        return cls(
+            tags=[
+                TagConfig(
+                    tag_name=tag_config["tag_name"],
+                    variant_config=VariantConfig(**tag_config["variant_config"]),
+                )
+                for tag_config in config_dict.get("tags")
+            ]
+        )
+
+
+class EnforceTagsForVariants(Rule):
+    """
+    Enforce tags presence in variant definitions.
+
+    The configuration example:
+
+    ```
+    - rule: "enforce-tags-for-variants"
+      tags:
+        # the rule will fail if the variant has matching configuration
+        # and is not tagged with the tag that matches tag_name
+        # and vice-versa
+        - tag_name: "required"
+          variant_config:
+            name_regex: ".*"
+            display_name_regex: "^!.+$"
+    ```
+
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "enforce-tags-for-variants"
+
+    @staticmethod
+    def defaults() -> dict:
+        return {"tags": []}
+
+    def __call__(self, config: dict, yaml: dict) -> List[LintError]:
+        variant_is_not_tagged_error_msg = (
+            "Build variant '{variant}' should be tagged with '{tag}',"
+            " because build variant configuration matches the following:"
+            " {variant_config}"
+        )
+        variant_config_not_matches_error_msg = (
+            "Tag '{tag}' should be removed from build variant '{variant}'"
+            " because build variant configuration does not match the following:"
+            " {variant_config}"
+        )
+
+        failed_checks = []
+        rule_config = EnforceTagsForVariantsConfig.from_config_dict(config)
+
+        for variant_def in cast(List, yaml.get("buildvariants", [])):
+            for cfg in rule_config.tags:
+                variant_is_tagged = cfg.tag_name in variant_def.get("tags", [])
+
+                variant_config_checks: List[bool] = []
+                if cfg.variant_config.name_regex:
+                    variant_config_checks.append(
+                        re.match(
+                            cfg.variant_config.name_regex,
+                            variant_def["name"],
+                        )
+                        is not None
+                    )
+                if cfg.variant_config.display_name_regex:
+                    variant_config_checks.append(
+                        re.match(
+                            cfg.variant_config.display_name_regex,
+                            variant_def["display_name"],
+                        )
+                        is not None
+                    )
+                variant_config_matches = all(variant_config_checks)
+
+                if variant_config_matches and not variant_is_tagged:
+                    failed_checks.append(
+                        variant_is_not_tagged_error_msg.format(
+                            tag=cfg.tag_name,
+                            variant=variant_def["name"],
+                            variant_config=cfg.variant_config.print(),
+                        )
+                    )
+
+                if variant_is_tagged and not variant_config_matches:
+                    failed_checks.append(
+                        variant_config_not_matches_error_msg.format(
+                            tag=cfg.tag_name,
+                            variant=variant_def["name"],
+                            variant_config=cfg.variant_config.print(),
+                        )
+                    )
+
+        return failed_checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen-lint"
-version = "0.1.5"  # Duplicated in the top-level __init__.py.
+version = "0.1.6"  # Duplicated in the top-level __init__.py.
 description = ""
 authors = [
     "DevProd Build Team <devprod-build-team@mongodb.com>",

--- a/tests/test_evergreen_lint.py
+++ b/tests/test_evergreen_lint.py
@@ -7,7 +7,7 @@ from evergreen_lint.rules import RULES
 
 
 def test_version():
-    assert __version__ == "0.1.5"
+    assert __version__ == "0.1.6"
 
 
 def test_stub_formatting():

--- a/tests/test_rule_enforce_tags_for_variants.py
+++ b/tests/test_rule_enforce_tags_for_variants.py
@@ -1,0 +1,143 @@
+import unittest
+
+from evergreen_lint import rules
+from evergreen_lint.yamlhandler import load
+
+
+class TestEnforceTagsForVariants(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rule = rules.enforce_tags_for_variants.EnforceTagsForVariants()
+
+    def test_tag_presence_is_enforced(self):
+        rule_config = {
+            "tags": [
+                {
+                    "tag_name": "required",
+                    "variant_config": {
+                        "name_regex": ".*",
+                        "display_name_regex": "^! .+$",
+                    },
+                },
+                {
+                    "tag_name": "suggested",
+                    "variant_config": {
+                        "name_regex": ".*",
+                        "display_name_regex": "^\\* .+$",
+                    },
+                },
+            ]
+        }
+
+        yaml = load(
+            """
+            buildvariants:
+            - name: variant-1
+              display_name: "! Variant 1"
+              tags: ["required"]
+            - name: variant-2
+              display_name: "* Variant 2"
+              tags: ["suggested"]
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_variant_is_missing_tag(self):
+        rule_config = {
+            "tags": [
+                {
+                    "tag_name": "required",
+                    "variant_config": {
+                        "name_regex": ".*",
+                        "display_name_regex": "^! .+$",
+                    },
+                },
+            ]
+        }
+
+        yaml = load(
+            """
+            buildvariants:
+            - name: variant-1
+              display_name: "! Variant 1"
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_variant_name_is_incorrect(self):
+        rule_config = {
+            "tags": [
+                {
+                    "tag_name": "required",
+                    "variant_config": {
+                        "name_regex": "^.*-suggested$",
+                        "display_name_regex": "^! .+$",
+                    },
+                },
+            ]
+        }
+
+        yaml = load(
+            """
+            buildvariants:
+            - name: variant-1
+              display_name: "! Variant 1"
+              tags: ["required"]
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_variant_display_name_is_incorrect(self):
+        rule_config = {
+            "tags": [
+                {
+                    "tag_name": "required",
+                    "variant_config": {
+                        "name_regex": ".*",
+                        "display_name_regex": "^! .+$",
+                    },
+                },
+            ]
+        }
+
+        yaml = load(
+            """
+            buildvariants:
+            - name: variant-1
+              display_name: "Variant 1"
+              tags: ["required"]
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_entire_variant_configuration_is_incorrect(self):
+        rule_config = {
+            "tags": [
+                {
+                    "tag_name": "required",
+                    "variant_config": {
+                        "name_regex": "^.*-suggested$",
+                        "display_name_regex": "^! .+$",
+                    },
+                },
+            ]
+        }
+
+        yaml = load(
+            """
+            buildvariants:
+            - name: variant-1
+              display_name: "Variant 1"
+              tags: ["required"]
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)


### PR DESCRIPTION
Context
---
This adds buildvariant tags linting:
1. It checks that the variant with matching name and/or display name is tagged
2. It checks that the tagged variant matches specified name and display name.

Testing
---
1. Unit tests.
2. Ran linter against the current evergreen yml in the mongo repo
    - configuration:
    ```yaml
        - rule: "enforce-tags-for-variants"
          tags:
            # Required variants should have "required" tag
            - tag_name: "required"
              variant_config:
                display_name_regex: "^! .+$"
            # Suggested variants should have "suggested" tag
            - tag_name: "suggested"
              variant_config:
                display_name_regex: "^\\* .+$"
    ```
    - ran commands:
    ```bash
    evergreen evaluate <mongo_repo>/etc/evergreen.yml > <mongo_repo>/etc/evaluated_evergreen.yml
    poetry run main -c <mongo_repo>/etc/evergreen_lint.yml lint
    ```
    - got results in ~5-10 seconds
    ```bash
    Load config file: /Users/misha/mongo/etc/evergreen_lint.yml
    37 errors found in '/Users/misha/mongo/etc/evaluated_evergreen.yml':
    For help resolving errors, see the helpful documentation at https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=133273894
    enforce-tags-for-variants: Build variant 'linux-64-debug-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'copybara-sync-between-repos' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-windows-benchmarks' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-amazon-linux2-arm64' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'rhel80-debug-ubsan-all-feature-flags' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-debug-aubsan-compile-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel-80-benchmarks' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel-80-64-bit-dynamic-config-shard' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'ubuntu2204-arm64-bazel-compile' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'windows-compile-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'amazon-linux2-arm64-dev-compile' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'amazon-linux2-arm64-stitch-compile' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-x86-dynamic-debug-compile-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'run-all-affected-jstests' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-amazon-linux2-arm64-all-feature-flags' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel80-debug-tsan' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-stitch-compile-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel-80-64-bit-dynamic-all-feature-flags' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'generate-tasks-for-version' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'rhel80-debug-aubsan-lite' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'amazon-linux2-arm64-dynamic-compile' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'rhel80-debug-aubsan-lite-all-feature-flags-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel-80-64-bit-dynamic' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-crypt-compile' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'windows-debug-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-rhel-80-64-bit-dynamic-embedded-router' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-x86-dynamic-grpc-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-windows-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'al2023-arm64-sep-benchmark' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'windows-dev-compile-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'amazon-linux2-arm64-crypt-compile' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'enterprise-windows-all-feature-flags-required' should be tagged with 'required', because build variant configuration matches the following: 
      display_name_regex: "^! .+$"
    
    enforce-tags-for-variants: Build variant 'stm-daily-cron' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'rhel80-debug-aubsan-all-feature-flags' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'macos-debug-suggested' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'linux-x86-dynamic-compile' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    
    enforce-tags-for-variants: Build variant 'rhel80-debug-aubsan-classic-engine' should be tagged with 'suggested', because build variant configuration matches the following: 
      display_name_regex: "^\* .+$"
    ```