### PR TITLE
DEVPROD-7379 Fix required-expansions-write check

### DIFF
--- a/evergreen_lint/__init__.py
+++ b/evergreen_lint/__init__.py
@@ -1,3 +1,3 @@
 """I exist to appease the linter."""
 
-__version__ = "0.1.6"  # Duplicated in pyproject.toml.
+__version__ = "0.1.7"  # Duplicated in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen-lint"
-version = "0.1.6"  # Duplicated in the top-level __init__.py.
+version = "0.1.7"  # Duplicated in the top-level __init__.py.
 description = ""
 authors = [
     "DevProd Build Team <devprod-build-team@mongodb.com>",

--- a/tests/test_evergreen_lint.py
+++ b/tests/test_evergreen_lint.py
@@ -7,7 +7,7 @@ from evergreen_lint.rules import RULES
 
 
 def test_version():
-    assert __version__ == "0.1.6"
+    assert __version__ == "0.1.7"
 
 
 def test_stub_formatting():

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -532,6 +532,89 @@ tasks:
         ]
 
 
+REQUIRED_EXPANSIONS_WRITE_ERRORS = [
+    "Function 'test1', command 0 calls an evergreen shell script without a "
+    "preceding expansions.write call. Always call expansions.write with params: "
+    "file: expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Function 'test2c', command 1 calls an evergreen shell script without a "
+    "preceding expansions.write call. Always call expansions.write with params: "
+    "file: expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Function 'test3a', command 1 calls an evergreen shell script without a "
+    "preceding expansions.write call. Always call expansions.write with params: "
+    "file: expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Function 'test4b', command 0 is an expansions.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "expansions.update.",
+    "Function 'test4d', command 1 calls an evergreen shell script without a "
+    "preceding expansions.write call. Always call expansions.write with params: "
+    "file: expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Function 'test5', command 0 is an expansions.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "expansions.update.",
+    "Function 'test6', command 1, (function call: dangerous_fn2) is an "
+    "expansions.update command that is not immediately followed by an "
+    "expansions.write call. Always call expansions.write with params: file: "
+    "expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) after calling expansions.update.",
+    "Function 'test7', command 2 is an timeout.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "timeout.update.",
+    "Function 'test8b', command 0 is an expansions.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "expansions.update.",
+    "Function 'test8b', command 4 is an timeout.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "timeout.update.",
+    "Task 'test', command 1 calls an evergreen shell script without a preceding "
+    "expansions.write call. Always call expansions.write with params: file: "
+    "expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Task 'test1', command 0, (function call: dangerous_fn) calls an evergreen "
+    "shell script without a preceding expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) before calling an evergreen "
+    "shell script via subprocess.exec.",
+    "Task 'test2', command 0 is an expansions.update command that is not "
+    "immediately followed by an expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) after calling "
+    "expansions.update.",
+    "Task 'test2', command 2 calls an evergreen shell script without a preceding "
+    "expansions.write call. Always call expansions.write with params: file: "
+    "expansions.yml; redacted: true, (or use one of these functions: "
+    "['f_expansions_write']) before calling an evergreen shell script via "
+    "subprocess.exec.",
+    "Task 'test3', command 0, (function call: dangerous_fn) calls an evergreen "
+    "shell script without a preceding expansions.write call. Always call "
+    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
+    "one of these functions: ['f_expansions_write']) before calling an evergreen "
+    "shell script via subprocess.exec.",
+    "Task 'test1', command 0 (function call: 'dangerous_fn') cannot safely take "
+    "arguments. Call expansions.write with params: file: expansions.yml; "
+    "redacted: true, (or use one of these functions: ['f_expansions_write']) in "
+    "the function, or do not pass arguments to it.",
+]
+
+
 class TestRequiredExpansionsWrite(_BaseTestClasses.RuleTest):
     """Test required-expansions-write."""
 
@@ -542,279 +625,502 @@ class TestRequiredExpansionsWrite(_BaseTestClasses.RuleTest):
             {
                 "raw_yaml": """
 functions:
-    # this function can serve in lieu of an expansions.write call
-    "f_expansions_write": &f_expansions_write
-        command: expansions.write
-        params:
-          file: expansions.yml
-          redacted: true
+  # this function can serve in lieu of an expansions.write call
+  "f_expansions_write": &f_expansions_write
+    command: expansions.write
+    params:
+      file: expansions.yml
+      redacted: true
 
-    # this function cannot, because redacted is not True
-    "f_expansions_write2": &f_expansions_write2
-        command: expansions.write
-        params:
-          file: expansions.yml
+  # this function cannot, because redacted is not True
+  "f_expansions_write2": &f_expansions_write2
+    command: expansions.write
+    params:
+      file: expansions.yml
 
-    "dangerous_fn": &dangerous_fn
-        # will not generate errors because this is a dict defintion. Errors
-        # will be generated if this function is called with arguments
-        command: subprocess.exec
+  "dangerous_fn": &dangerous_fn
+    # will not generate errors because this is a single command function,
+    # errors will be generated if this function is called with arguments
+    command: subprocess.exec
+    params:
+      binary: bash
+      args:
+        - "src/evergreen/do_something.sh"
+
+  "dangerous_fn2": &dangerous_fn2
+    # will not generate errors because this is a single command function
+    command: expansions.update
+
+  "test1":
+    # needs expansions.write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+    # only ONE of these should generate an error
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test2a":
+    # correct
+    - func: "f_expansions_write"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test2b":
+    # correct
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test2c":
+    # function isn't a compatible substitution
+    - *f_expansions_write2
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test3":
+    # correct because the subprocess.exec call is a script outside
+    # of evergreen
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "somewhere/else/do_something.sh"
+
+  "test3a":
+    # needs expansions.write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "somewhere/else/do_something.sh"
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test4b":
+    # need an expansions.write call after expansions.update
+    - command: expansions.update
+    - command: shell.exec
+    - *f_expansions_write
+
+  "test4c":
+    # no errors
+    - command: expansions.update
+    - *f_expansions_write
+
+  "test4d":
+    # errors, because an incompatible function is called
+    - *f_expansions_write2
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test5":
+    # errors, because an incompatible function is called
+    - command: expansions.update
+    - func: f_expansions_write2
+
+  "test6":
+    # error because this needs an expansions write call after dangerous_fn2
+    - *f_expansions_write
+    - func: "dangerous_fn2"
+      vars:
+        test: test
+
+  "test7":
+    # error, needs an expansion.write at the end
+    - command: expansions.update
+    - *f_expansions_write
+    - command: timeout.update
+
+  "test8":
+    # no errors
+    - command: expansions.update
+    - *f_expansions_write
+    - command: timeout.update
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "somewhere/else/do_something.sh"
+    - command: timeout.update
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+  "test8b":
+    - command: expansions.update
+    - command: timeout.update
+    - *f_expansions_write
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "somewhere/else/do_something.sh"
+    - command: timeout.update
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - "src/evergreen/do_something.sh"
+
+tasks:
+  - name: test
+    commands:
+      # need an expansions.write call here
+      - command: shell.exec
+      - command: subprocess.exec
         params:
           binary: bash
           args:
             - "src/evergreen/do_something.sh"
 
-    "dangerous_fn2": &dangerous_fn2
-        # will not generate errors because this is a dict defintion.
-        command: expansions.update
+  - name: test1
+    commands:
+      - func: "dangerous_fn"
+        vars:
+          test: true
 
-    "test1":
-        # needs expansions.write
+  - name: test2
+    commands:
+      # need an expansions.write call after expansions.update
+      - command: expansions.update
+      - command: shell.exec
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - "src/evergreen/do_something.sh"
+
+  - name: test3
+    commands:
+      # an expansions.write call is required here.
+      - func: dangerous_fn
+        """,
+                "errors": REQUIRED_EXPANSIONS_WRITE_ERRORS,
+            },
+        ]
+
+
+class TestRequiredExpansionsWriteAgainstEvaluatedYaml(_BaseTestClasses.RuleTest):
+    """Test required-expansions-write."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.func = rules.required_expansions_write.RequiredExpansionsWrite()
+        self.table = [
+            {
+                "raw_yaml": """
+oom_tracker: true
+functions:
+    dangerous_fn:
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "src/evergreen/do_something.sh"
-        # only ONE of these should generate an error
-        - command: subprocess.exec
-          params:
+                - src/evergreen/do_something.sh
             binary: bash
+          params_yaml: |
             args:
-              - "src/evergreen/do_something.sh"
-    "test2a":
-        # correct
-        - func: "f_expansions_write"
-        - command: subprocess.exec
-          params:
+                - src/evergreen/do_something.sh
             binary: bash
-            args:
-              - "src/evergreen/do_something.sh"
-    "test2b":
-        # correct
-        - *f_expansions_write
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - "src/evergreen/do_something.sh"
-    "test2c":
-        # function isn't a compatible substitution
-        - *f_expansions_write2
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - "src/evergreen/do_something.sh"
-    "test3":
-        # correct because the subprocess.exec call is a script outside
-        # of evergreen
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - "somewhere/else/do_something.sh"
-    "test3a":
-        # needs expansions.write
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - "somewhere/else/do_something.sh"
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - "src/evergreen/do_something.sh"
-    "test4a":
-        # need an expansions.write call after expansions.update
+    dangerous_fn2:
         - command: expansions.update
-    "test4b":
-        # need an expansions.write call after expansions.update
+    f_expansions_write:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
+    f_expansions_write2:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+          params_yaml: |
+            file: expansions.yml
+    test1:
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test2a:
+        - func: f_expansions_write
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test2b:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test2c:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+          params_yaml: |
+            file: expansions.yml
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test3:
+        - command: subprocess.exec
+          params:
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
+    test3a:
+        - command: subprocess.exec
+          params:
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test4b:
         - command: expansions.update
         - command: shell.exec
-        - *f_expansions_write
-    "test4c":
-        # no errors
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
+    test4c:
         - command: expansions.update
-        - *f_expansions_write
-    "test4d":
-        # errors, because an incompatible function is called
-        - *f_expansions_write2
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
+    test4d:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+          params_yaml: |
+            file: expansions.yml
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "src/evergreen/do_something.sh"
-    "test5":
-        # errors, because an incompatible function is called
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test5:
         - command: expansions.update
         - func: f_expansions_write2
-
-    "test6":
-        # error because this needs an expansions write call after dangerous_fn2
-        - *f_expansions_write
-        - func: "dangerous_fn2"
+    test6:
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
+        - func: dangerous_fn2
           vars:
             test: test
-
-    "test7":
-        # error, needs an expansion.write at the end
+    test7:
         - command: expansions.update
-        - *f_expansions_write
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
         - command: timeout.update
-
-    "test8":
-        # no errors
+    test8:
         - command: expansions.update
-        - *f_expansions_write
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
         - command: timeout.update
-        - *f_expansions_write
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "somewhere/else/do_something.sh"
+                - somewhere/else/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
         - command: timeout.update
-        - *f_expansions_write
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "src/evergreen/do_something.sh"
-
-    "test8b":
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    test8b:
         - command: expansions.update
         - command: timeout.update
-        - *f_expansions_write
+        - command: expansions.write
+          params:
+            file: expansions.yml
+            redacted: true
+          params_yaml: |
+            file: expansions.yml
+            redacted: true
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "somewhere/else/do_something.sh"
+                - somewhere/else/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - somewhere/else/do_something.sh
+            binary: bash
         - command: timeout.update
         - command: subprocess.exec
           params:
-            binary: bash
             args:
-              - "src/evergreen/do_something.sh"
-
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
 tasks:
-- name: test
-  commands:
-    # need an expansions.write call here
-    - command: shell.exec
-    - command: subprocess.exec
-      params:
-        binary: bash
-        args:
-          - "src/evergreen/do_something.sh"
-- name: test1
-  commands:
-    - func: "dangerous_fn"
-      vars:
-        test: true
+    - name: test
+      commands:
+        - command: shell.exec
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    - name: test1
+      commands:
+        - func: dangerous_fn
+          vars:
+            test: "true"
+    - name: test2
+      commands:
+        - command: expansions.update
+        - command: shell.exec
+        - command: subprocess.exec
+          params:
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+          params_yaml: |
+            args:
+                - src/evergreen/do_something.sh
+            binary: bash
+    - name: test3
+      commands:
+        - func: dangerous_fn
 
-- name: test2
-  commands:
-  # need an expansions.write call after expansions.update
-    - command: expansions.update
-    - command: shell.exec
-    - command: subprocess.exec
-      params:
-        binary: bash
-        args:
-          - "src/evergreen/do_something.sh"
-- name: test3
-  commands:
-    # an expansions.write call is required here.
-    - func: dangerous_fn
+
         """,
-                "errors": [
-                    "Function 'test1', command 0 calls an evergreen shell script without a "
-                    "preceding expansions.write call. Always call expansions.write with params: "
-                    "file: expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Function 'test2c', command 1 calls an evergreen shell script without a "
-                    "preceding expansions.write call. Always call expansions.write with params: "
-                    "file: expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Function 'test3a', command 1 calls an evergreen shell script without a "
-                    "preceding expansions.write call. Always call expansions.write with params: "
-                    "file: expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Function 'test4a', command 0 is an expansions.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "expansions.update.",
-                    "Function 'test4b', command 0 is an expansions.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "expansions.update.",
-                    "Function 'test4d', command 1 calls an evergreen shell script without a "
-                    "preceding expansions.write call. Always call expansions.write with params: "
-                    "file: expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Function 'test5', command 0 is an expansions.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "expansions.update.",
-                    "Function 'test6', command 1, (function call: dangerous_fn2) is an "
-                    "expansions.update command that is not immediately followed by an "
-                    "expansions.write call. Always call expansions.write with params: file: "
-                    "expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) after calling expansions.update.",
-                    "Function 'test7', command 2 is an timeout.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "timeout.update.",
-                    "Function 'test8b', command 0 is an expansions.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "expansions.update.",
-                    "Function 'test8b', command 4 is an timeout.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "timeout.update.",
-                    "Task 'test', command 1 calls an evergreen shell script without a preceding "
-                    "expansions.write call. Always call expansions.write with params: file: "
-                    "expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Task 'test1', command 0, (function call: dangerous_fn) calls an evergreen "
-                    "shell script without a preceding expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) before calling an evergreen "
-                    "shell script via subprocess.exec.",
-                    "Task 'test2', command 0 is an expansions.update command that is not "
-                    "immediately followed by an expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) after calling "
-                    "expansions.update.",
-                    "Task 'test2', command 2 calls an evergreen shell script without a preceding "
-                    "expansions.write call. Always call expansions.write with params: file: "
-                    "expansions.yml; redacted: true, (or use one of these functions: "
-                    "['f_expansions_write']) before calling an evergreen shell script via "
-                    "subprocess.exec.",
-                    "Task 'test3', command 0, (function call: dangerous_fn) calls an evergreen "
-                    "shell script without a preceding expansions.write call. Always call "
-                    "expansions.write with params: file: expansions.yml; redacted: true, (or use "
-                    "one of these functions: ['f_expansions_write']) before calling an evergreen "
-                    "shell script via subprocess.exec.",
-                    "Task 'test1', command 0 (function call: 'dangerous_fn') cannot safely take "
-                    "arguments. Call expansions.write with params: file: expansions.yml; "
-                    "redacted: true, (or use one of these functions: ['f_expansions_write']) in "
-                    "the function, or do not pass arguments to it.",
-                ],
+                "errors": REQUIRED_EXPANSIONS_WRITE_ERRORS,
             },
         ]
 


### PR DESCRIPTION
Context
---

To understand what is the purpose of `required-expansions-write` check, please read [here](https://github.com/MikhailShchatko/config-linter/blob/3269ce07436c64038020070acf1046d0efe165f0/evergreen_lint/rules/required_expansions_write.py#L23-L100). 

`evergreen evaluate` turns functions that have dictionary definitions, like "function_name": "function_body", into list definitions, like "function_name": ["function_body"].

For example, from this

```yaml
functions:
  f_expansions_write:
    command: expansions.write
    params:
      file: expansions.yml
      redacted: true
```

into this

```yaml
functions:
    f_expansions_write:
        - command: expansions.write
          params:
            file: expansions.yml
            redacted: true
          params_yaml: |
            file: expansions.yml
            redacted: true
```

This way `required-expansions-write` check didn't work properly for `evergreen evaluate` output.

With these PR changes it should work with both evaluated and original evergreen yamls equally.

Testing
---

Unit tests and testing locally against 10gen/mongo evergreen ymls.
