### PR TITLE
DEVPROD-7436 Add variant expansions linting

### DIFF
--- a/evergreen_lint/__init__.py
+++ b/evergreen_lint/__init__.py
@@ -1,3 +1,3 @@
 """I exist to appease the linter."""
 
-__version__ = "0.1.7"  # Duplicated in pyproject.toml.
+__version__ = "0.1.8"  # Duplicated in pyproject.toml.

--- a/evergreen_lint/config.py
+++ b/evergreen_lint/config.py
@@ -135,6 +135,11 @@ rules:
     # Enforce variants must have tags
     - rule: "enforce-tags-for-variants"
       tags: {[]}
+
+    # Validate variant expansions
+    - rule: "variant-expansions"
+      require_expansions: {[]}
+      prohibit_expansions: {[]}
 """[
     1:-1
 ]  # <--- this strips the leading and trailing newlines from this HEREDOC

--- a/evergreen_lint/rules/__init__.py
+++ b/evergreen_lint/rules/__init__.py
@@ -16,6 +16,7 @@ from evergreen_lint.rules.enforce_tags_for_variants import EnforceTagsForVariant
 from evergreen_lint.rules.invalid_build_parameter import InvalidBuildParameter
 from evergreen_lint.rules.required_expansions_write import RequiredExpansionsWrite
 from evergreen_lint.rules.tasks_for_variants import TasksForVariants
+from evergreen_lint.rules.variant_expansions import VariantExpansions
 
 RULES: Dict[str, Type[Rule]] = {
     "limit-keyval-inc": LimitKeyvalInc,
@@ -30,6 +31,7 @@ RULES: Dict[str, Type[Rule]] = {
     "tasks-for-variants": TasksForVariants,
     "enforce-tags-for-tasks": EnforceTagsForTasks,
     "enforce-tags-for-variants": EnforceTagsForVariants,
+    "variant-expansions": VariantExpansions,
 }
 # Thoughts on Writing Rules
 # - see .helpers for reliable iteration helpers

--- a/evergreen_lint/rules/variant_expansions.py
+++ b/evergreen_lint/rules/variant_expansions.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, NamedTuple, Optional, cast
+
+from evergreen_lint.model import LintError, Rule
+
+
+def compile_optional_regex(regex: Optional[str]) -> Optional[re.Pattern]:
+    return re.compile(regex) if regex is not None else None
+
+
+class VariantConfig(NamedTuple):
+    name_regex: Optional[re.Pattern] = None
+    display_name_regex: Optional[re.Pattern] = None
+    task_presence_regex: Optional[re.Pattern] = None
+    task_absense_regex: Optional[re.Pattern] = None
+
+    @classmethod
+    def from_variant_config_dict(cls, config_dict: Optional[Dict[str, Any]]) -> VariantConfig:
+        if config_dict is None:
+            return cls()
+        return cls(
+            name_regex=compile_optional_regex(config_dict.get("name_regex")),
+            display_name_regex=compile_optional_regex(config_dict.get("display_name_regex")),
+            task_presence_regex=compile_optional_regex(config_dict.get("task_presence_regex")),
+            task_absense_regex=compile_optional_regex(config_dict.get("task_absense_regex")),
+        )
+
+    def matches_variant_definition(self, variant_definition: Dict[str, Any]) -> bool:
+        checks = []
+        if self.name_regex is not None:
+            checks.append(self.name_regex.match(variant_definition.get("name") or "") is not None)
+        if self.display_name_regex is not None:
+            checks.append(
+                self.display_name_regex.match(variant_definition.get("display_name") or "")
+                is not None
+            )
+        if self.task_presence_regex is not None:
+            checks.append(
+                any(
+                    self.task_presence_regex.match(task.get("name") or "") is not None
+                    for task in variant_definition.get("tasks") or []
+                )
+            )
+        if self.task_absense_regex is not None:
+            checks.append(
+                all(
+                    self.task_absense_regex.match(task.get("name") or "") is None
+                    for task in variant_definition.get("tasks") or []
+                )
+            )
+        return all(checks)
+
+    def print(self, indent: int = 2) -> str:
+        output = ""
+        prefix = " " * indent
+
+        for key, value in self._asdict().items():
+            if value is not None:
+                output = (
+                    f"{output}\n{prefix}{key}:"
+                    f' "{value.pattern if isinstance(value, re.Pattern) else value}"'
+                )
+
+        return output
+
+
+class ExpansionConfig(NamedTuple):
+    expansion_name: str
+    variant_config: VariantConfig
+    expansion_value_regex: Optional[re.Pattern] = None
+
+    @classmethod
+    def from_expansion_config_dict(cls, config_dict: Dict[str, Any]) -> ExpansionConfig:
+        return cls(
+            expansion_name=config_dict["expansion_name"],
+            expansion_value_regex=compile_optional_regex(config_dict.get("expansion_value_regex")),
+            variant_config=VariantConfig.from_variant_config_dict(
+                config_dict.get("variant_config")
+            ),
+        )
+
+
+class VariantExpansionsConfig(NamedTuple):
+    require_expansions: List[ExpansionConfig]
+    prohibit_expansions: List[ExpansionConfig]
+
+    @classmethod
+    def from_config_dict(cls, config_dict: Dict[str, Any]) -> VariantExpansionsConfig:
+        return cls(
+            require_expansions=[
+                ExpansionConfig.from_expansion_config_dict(expansion_config)
+                for expansion_config in config_dict.get("require_expansions") or []
+            ],
+            prohibit_expansions=[
+                ExpansionConfig.from_expansion_config_dict(expansion_config)
+                for expansion_config in config_dict.get("prohibit_expansions") or []
+            ],
+        )
+
+
+class VariantExpansions(Rule):
+    """
+    Validate expansions in variant definitions.
+
+    The configuration example:
+
+    ```
+    - rule: "variant-expansions"
+      require_expansions:
+        - expansion_name: "require-expansion-when-task-1-runs-on-variant"
+          expansion_value_regex: ".*"
+          variant_config:
+            name_regex: ".*"
+            display_name_regex: ".*"
+            task_presence_regex: "task-1"
+        - expansion_name: "require-expansion-when-task-2-does-not-run-on-variant"
+          expansion_value_regex: ".*"
+          variant_config:
+            name_regex: ".*"
+            display_name_regex: ".*"
+            task_absense_regex: "task-2"
+      prohibit_expansions:
+        - expansion_name: "prohibit-expansion-when-task-3-runs-on-variant"
+          expansion_value_regex: ".*"
+          variant_config:
+            name_regex: ".*"
+            display_name_regex: ".*"
+            task_presence_regex: "task-3"
+        - expansion_name: "prohibit-expansion-when-task-4-does-not-run-on-variant"
+          expansion_value_regex: ".*"
+          variant_config:
+            name_regex: ".*"
+            display_name_regex: ".*"
+            task_absense_regex: "task-4"
+    ```
+
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "variant-expansions"
+
+    @staticmethod
+    def defaults() -> dict:
+        return {"require_expansions": [], "prohibit_expansions": []}
+
+    def __call__(self, config: dict, yaml: dict) -> List[LintError]:
+        require_expansion_error_msg = (
+            "Build variant expansion '{expansion_name}' should be added to '{variant}'"
+            " build variant, because build variant configuration matches the following:"
+            " {variant_config}"
+        )
+        prohibit_expansion_error_msg = (
+            "Build variant expansion '{expansion_name}' should be removed from '{variant}'"
+            " build variant, because build variant configuration matches the following:"
+            " {variant_config}"
+        )
+        require_expansion_with_value_error_msg = (
+            "Build variant expansion '{expansion_name}' value should match"
+            " '{expansion_value_regex}' pattern on '{variant}' build variant, because"
+            " build variant configuration matches the following:"
+            " {variant_config}"
+        )
+        prohibit_expansion_with_value_error_msg = (
+            "Build variant expansion '{expansion_name}' value should not match"
+            " '{expansion_value_regex}' pattern on '{variant}' build variant, because"
+            " build variant configuration matches the following:"
+            " {variant_config}"
+        )
+
+        failed_checks = []
+        rule_config = VariantExpansionsConfig.from_config_dict(config)
+
+        for variant_def in cast(List, yaml.get("buildvariants") or []):
+            variant_name = variant_def["name"]
+            variant_expansions = variant_def.get("expansions") or {}
+
+            for require_config in rule_config.require_expansions:
+                if not require_config.variant_config.matches_variant_definition(variant_def):
+                    continue
+                expansion_to_validate = variant_expansions.get(require_config.expansion_name)
+                if expansion_to_validate is None:
+                    failed_checks.append(
+                        require_expansion_error_msg.format(
+                            expansion_name=require_config.expansion_name,
+                            variant=variant_name,
+                            variant_config=require_config.variant_config.print(),
+                        )
+                    )
+                elif (
+                    require_config.expansion_value_regex is not None
+                    and require_config.expansion_value_regex.match(expansion_to_validate) is None
+                ):
+                    failed_checks.append(
+                        require_expansion_with_value_error_msg.format(
+                            expansion_name=require_config.expansion_name,
+                            expansion_value_regex=require_config.expansion_value_regex.pattern,
+                            variant=variant_name,
+                            variant_config=require_config.variant_config.print(),
+                        )
+                    )
+
+            for prohibit_config in rule_config.prohibit_expansions:
+                if not prohibit_config.variant_config.matches_variant_definition(variant_def):
+                    continue
+                expansion_to_validate = variant_expansions.get(prohibit_config.expansion_name)
+                if (
+                    prohibit_config.expansion_value_regex is None
+                    and expansion_to_validate is not None
+                ):
+                    failed_checks.append(
+                        prohibit_expansion_error_msg.format(
+                            expansion_name=prohibit_config.expansion_name,
+                            variant=variant_name,
+                            variant_config=prohibit_config.variant_config.print(),
+                        )
+                    )
+                elif (
+                    prohibit_config.expansion_value_regex is not None
+                    and expansion_to_validate is not None
+                    and prohibit_config.expansion_value_regex.match(expansion_to_validate)
+                    is not None
+                ):
+                    failed_checks.append(
+                        prohibit_expansion_with_value_error_msg.format(
+                            expansion_name=prohibit_config.expansion_name,
+                            expansion_value_regex=prohibit_config.expansion_value_regex.pattern,
+                            variant=variant_name,
+                            variant_config=prohibit_config.variant_config.print(),
+                        )
+                    )
+
+        return failed_checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evergreen-lint"
-version = "0.1.7"  # Duplicated in the top-level __init__.py.
+version = "0.1.8"  # Duplicated in the top-level __init__.py.
 description = ""
 authors = [
     "DevProd Build Team <devprod-build-team@mongodb.com>",

--- a/tests/test_evergreen_lint.py
+++ b/tests/test_evergreen_lint.py
@@ -7,7 +7,7 @@ from evergreen_lint.rules import RULES
 
 
 def test_version():
-    assert __version__ == "0.1.7"
+    assert __version__ == "0.1.8"
 
 
 def test_stub_formatting():

--- a/tests/test_variant_expansions.py
+++ b/tests/test_variant_expansions.py
@@ -1,0 +1,418 @@
+import unittest
+
+from evergreen_lint import rules
+from evergreen_lint.yamlhandler import load
+
+
+class TestVariantExpansions(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rule = rules.variant_expansions.VariantExpansions()
+        self.yaml = load(
+            """
+            buildvariants:
+            - name: existing-variant-name
+              display_name: "Existing Variant Display Name"
+              expansions:
+                existing_expansion_1: existing expansion value 1
+                existing_expansion_2: existing expansion value 2
+              tasks:
+              - name: existing_task_1
+              - name: existing_task_2
+            """
+        )
+
+    def test_required_expansion_is_present_minimal_config(self):
+        rule_config = {
+            "require_expansions": [{"expansion_name": "existing_expansion_1"}],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_is_absent_minimal_config(self):
+        rule_config = {
+            "require_expansions": [{"expansion_name": "non_existing_expansion"}],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_is_present_on_variant_with_name(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"name_regex": "existing-variant-name"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_is_absent_on_variant_with_name(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"name_regex": "existing-variant-name"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_is_present_on_variant_with_display_name(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"display_name_regex": "Existing Variant Display Name"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_is_absent_on_variant_with_display_name(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"display_name_regex": "Existing Variant Display Name"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_is_present_on_variant_when_task_present(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"task_presence_regex": "existing_task_1"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_is_absent_on_variant_when_task_present(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"task_presence_regex": "existing_task_1"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_is_present_on_variant_when_task_absent(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"task_absense_regex": "absent_task"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_is_absent_on_variant_when_task_absent(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"task_absense_regex": "absent_task"},
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_value_is_valid(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "existing expansion value 1",
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_value_is_invalid(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "invalid value",
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_required_expansion_value_is_valid_full_config(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "existing expansion value 1",
+                    "variant_config": {
+                        "name_regex": "existing-variant-name",
+                        "display_name_regex": "Existing Variant Display Name",
+                        "task_presence_regex": "existing_task_1",
+                        "task_absense_regex": "absent_task",
+                    },
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_required_expansion_value_is_invalid_full_config(self):
+        rule_config = {
+            "require_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "invalid value",
+                    "variant_config": {
+                        "name_regex": "existing-variant-name",
+                        "display_name_regex": "Existing Variant Display Name",
+                        "task_presence_regex": "existing_task_1",
+                        "task_absense_regex": "absent_task",
+                    },
+                }
+            ],
+            "prohibit_expansions": None,
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_present_minimal_config(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [{"expansion_name": "existing_expansion_1"}],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_absent_minimal_config(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [{"expansion_name": "non_existing_expansion"}],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_is_present_on_variant_with_name(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"name_regex": "existing-variant-name"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_absent_on_variant_with_name(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"name_regex": "existing-variant-name"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_is_present_on_variant_with_display_name(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"display_name_regex": "Existing Variant Display Name"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_absent_on_variant_with_display_name(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"display_name_regex": "Existing Variant Display Name"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_is_present_on_variant_when_task_present(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"task_presence_regex": "existing_task_1"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_absent_on_variant_when_task_present(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"task_presence_regex": "existing_task_1"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_is_present_on_variant_when_task_absent(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "variant_config": {"task_absense_regex": "absent_task"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_is_absent_on_variant_when_task_absent(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "non_existing_expansion",
+                    "variant_config": {"task_absense_regex": "absent_task"},
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_with_matching_value(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "existing expansion value 1",
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_with_non_matching_value(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "invalid value",
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_prohibited_expansion_with_matching_value_full_config(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "existing expansion value 1",
+                    "variant_config": {
+                        "name_regex": "existing-variant-name",
+                        "display_name_regex": "Existing Variant Display Name",
+                        "task_presence_regex": "existing_task_1",
+                        "task_absense_regex": "absent_task",
+                    },
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 1)
+
+    def test_prohibited_expansion_with_non_matching_value_full_config(self):
+        rule_config = {
+            "require_expansions": None,
+            "prohibit_expansions": [
+                {
+                    "expansion_name": "existing_expansion_1",
+                    "expansion_value_regex": "invalid value",
+                    "variant_config": {
+                        "name_regex": "existing-variant-name",
+                        "display_name_regex": "Existing Variant Display Name",
+                        "task_presence_regex": "existing_task_1",
+                        "task_absense_regex": "absent_task",
+                    },
+                }
+            ],
+        }
+
+        violations = self.rule(rule_config, self.yaml)
+        self.assertEqual(len(violations), 0)


### PR DESCRIPTION
# Issue

[DEVPROD-7436](https://jira.mongodb.org/browse/DEVPROD-7436) Add variant expansions linting to evergreen-ci/config-linter

# Description

With this linting rule we can validate that variants have necessary expansions or prohibit adding expansions.
Also we can validate expansion values or prohibit specific expansion values.

The configuration allows to apply the rule on variants based on the following criteria or combinations of them:
- variant name regex
- variant display name regex
- task presence on variant (regex)
- task absense on variant (regex)

Here are some examples of the rules configuration:

```yaml
  - rule: "variant-expansions"
    require_expansions:
      - expansion_name: "require-expansion-when-task-1-runs-on-variant"
        expansion_value_regex: ".*"
        variant_config:
          name_regex: ".*"
          display_name_regex: ".*"
          task_presence_regex: "task-1"
      - expansion_name: "require-expansion-when-task-2-does-not-run-on-variant"
        expansion_value_regex: ".*"
        variant_config:
          name_regex: ".*"
          display_name_regex: ".*"
          task_absense_regex: "task-2"
    prohibit_expansions:
      - expansion_name: "prohibit-expansion-when-task-3-runs-on-variant"
        expansion_value_regex: ".*"
        variant_config:
          name_regex: ".*"
          display_name_regex: ".*"
          task_presence_regex: "task-3"
      - expansion_name: "prohibit-expansion-when-task-4-does-not-run-on-variant"
        expansion_value_regex: ".*"
        variant_config:
          name_regex: ".*"
          display_name_regex: ".*"
          task_absense_regex: "task-4"
```

# Testing

Unit tests