### PR TITLE
DEVPROD-10242 Add experimental tag linting

### DIFF
--- a/evergreen_lint/rules/__init__.py
+++ b/evergreen_lint/rules/__init__.py
@@ -13,6 +13,7 @@ from evergreen_lint.rules.commonsense import (
 from evergreen_lint.rules.dependency_for_func import DependencyForFunc
 from evergreen_lint.rules.enforce_tags_for_tasks import EnforceTagsForTasks
 from evergreen_lint.rules.enforce_tags_for_variants import EnforceTagsForVariants
+from evergreen_lint.rules.prevent_experimental_tasks_in_non_experimental_variants import PreventExperimentalTasksInNonExperimentalVariants
 from evergreen_lint.rules.invalid_build_parameter import InvalidBuildParameter
 from evergreen_lint.rules.required_expansions_write import RequiredExpansionsWrite
 from evergreen_lint.rules.tasks_for_variants import TasksForVariants
@@ -32,6 +33,7 @@ RULES: Dict[str, Type[Rule]] = {
     "enforce-tags-for-tasks": EnforceTagsForTasks,
     "enforce-tags-for-variants": EnforceTagsForVariants,
     "variant-expansions": VariantExpansions,
+    "prevent-experimental-tasks-in-non-experimental-variants":PreventExperimentalTasksInNonExperimentalVariants,
 }
 # Thoughts on Writing Rules
 # - see .helpers for reliable iteration helpers

--- a/evergreen_lint/rules/prevent_experimental_tasks_in_non_experimental_variants.py
+++ b/evergreen_lint/rules/prevent_experimental_tasks_in_non_experimental_variants.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import List, Dict, Set
+
+from evergreen_lint.model import LintError, Rule
+
+
+class PreventExperimentalTasksInNonExperimentalVariants(Rule):
+    """
+    Prevent experimental tasks from being used in non-experimental buildvariants.
+
+    This rule checks that:
+    1. Tasks with the "experimental" tag are not used in buildvariants with the "no_task_tag_experimental" tag.
+    2. Ignores specified tasks even if they are experimental and in non-experimental buildvariants.
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "prevent-experimental-tasks-in-non-experimental-variants"
+
+    @staticmethod
+    def defaults() -> dict:
+        return {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental",
+            "ignored_tasks": []
+        }
+
+    @staticmethod
+    def _get_variant_tasks(variant: Dict) -> Set[str]:
+        return {task['name'] for task in variant.get('tasks', [])}
+
+    def __call__(self, config: dict, yaml: dict) -> List[LintError]:
+        failed_checks = []
+
+        task_experimental_tag = config.get("task_experimental_tag", "experimental")
+        variant_no_experimental_tag = config.get("variant_no_experimental_tag", "no_task_tag_experimental")
+        ignored_tasks = set(config.get("ignored_tasks", []))
+
+        # Find all experimental tasks
+        experimental_tasks: Set[str] = set()
+        for task in yaml.get("tasks", []):
+            if task_experimental_tag in task.get("tags", []):
+                experimental_tasks.add(task["name"])
+
+        # Check buildvariants
+        for variant in yaml.get("buildvariants", []):
+            variant_name = variant["name"]
+            variant_tags = set(variant.get("tags", []))
+            
+            if variant_no_experimental_tag not in variant_tags:
+                continue
+
+            variant_tasks = self._get_variant_tasks(variant)
+
+            for task_name in variant_tasks:
+                if task_name in experimental_tasks and task_name not in ignored_tasks:
+                    failed_checks.append(
+                        f"Experimental task '{task_name}' is used in buildvariant '{variant_name}' "
+                        f"which is tagged as '{variant_no_experimental_tag}'.\n"
+                    )
+        return failed_checks
+

--- a/evergreen_lint/rules/prevent_experimental_tasks_in_non_experimental_variants.py
+++ b/evergreen_lint/rules/prevent_experimental_tasks_in_non_experimental_variants.py
@@ -60,4 +60,3 @@ class PreventExperimentalTasksInNonExperimentalVariants(Rule):
                         f"which is tagged as '{variant_no_experimental_tag}'.\n"
                     )
         return failed_checks
-

--- a/tests/test_prevent_experimental_tasks_in_non_experimental_variants.py
+++ b/tests/test_prevent_experimental_tasks_in_non_experimental_variants.py
@@ -1,0 +1,152 @@
+import unittest
+import os
+import yaml
+
+from evergreen_lint import rules
+from evergreen_lint.yamlhandler import load
+
+
+class TestPreventExperimentalTasksInNonExperimentalVariants(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rule = rules.prevent_experimental_tasks_in_non_experimental_variants.PreventExperimentalTasksInNonExperimentalVariants()
+
+    def test_no_violations_when_experimental_tasks_in_appropriate_variants(self):
+        rule_config = {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental"
+        }
+
+        yaml = load(
+            """
+            tasks:
+            - name: task1
+              tags: ["experimental"]
+            - name: task2
+              tags: []
+            buildvariants:
+            - name: variant-1
+              tasks: 
+                - name: task2
+            - name: variant-2
+              tags: ["suggested"]
+              tasks:
+                - name: task1
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 0)
+
+    def test_violation_when_experimental_task_in_non_experimental_variant(self):
+        rule_config = {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental"
+        }
+
+        yaml = load(
+            """
+            tasks:
+              - name: task1
+                tags: ["experimental"]
+              - name: task2
+                tags: []
+            buildvariants:
+              - name: variant-1
+                tags: ["no_task_tag_experimental"]
+                tasks:
+                  - name: task1
+                  - name: task2
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("variant-1", violations[0])
+        self.assertIn("task1", violations[0])
+
+    def test_multiple_violations_across_different_variants(self):
+        rule_config = {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental"
+        }
+
+        yaml = load(
+            """
+            tasks:
+            - name: task1
+              tags: ["experimental"]
+            - name: task2
+              tags: ["experimental"]
+            - name: task3
+              tags: []
+            buildvariants:
+            - name: variant-1
+              tags: ["no_task_tag_experimental"]
+              tasks: 
+                - name: task1
+                - name: task3
+            - name: variant-2
+              tags: ["no_task_tag_experimental"]
+              tasks:
+                - name: task2
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 2)
+        self.assertIn("variant-1", violations[0])
+        self.assertIn("task1", violations[0])
+        self.assertIn("variant-2", violations[1])
+        self.assertIn("task2", violations[1])
+
+    def test_ignored_tasks_are_not_reported_as_violations(self):
+        rule_config = {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental",
+            "ignored_tasks": ["special_task"]
+        }
+
+        yaml = load(
+            """
+            tasks:
+            - name: task1
+              tags: ["experimental"]
+            - name: special_task
+              tags: ["experimental"]
+            buildvariants:
+            - name: variant-1
+              tags: ["no_task_tag_experimental"]
+              tasks: 
+                - name: task1
+                - name: special_task
+            """
+        )
+
+        violations = self.rule(rule_config, yaml)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("task1", violations[0])
+        self.assertNotIn("special_task", violations[0])
+
+    def test_with_actual_yaml(self):
+
+        yaml_path = "/home/ubuntu/mongo/etc/evaluated_evergreen.yml"
+        with open(yaml_path, 'r') as file:
+            yaml_content = yaml.safe_load(file)
+
+        rule_config = {
+            "task_experimental_tag": "experimental",
+            "variant_no_experimental_tag": "no_task_tag_experimental",
+            "ignored_tasks": [
+              "search_end_to_end_single_node"
+            ]
+        }
+        violations = self.rule(rule_config, yaml_content)
+
+        for violation in violations:
+            print(violation)
+
+        self.assertTrue(len(violations) > 0, "Expected at least one violation")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_prevent_experimental_tasks_in_non_experimental_variants.py
+++ b/tests/test_prevent_experimental_tasks_in_non_experimental_variants.py
@@ -1,6 +1,5 @@
 import unittest
-import os
-import yaml
+
 
 from evergreen_lint import rules
 from evergreen_lint.yamlhandler import load
@@ -126,27 +125,3 @@ class TestPreventExperimentalTasksInNonExperimentalVariants(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertIn("task1", violations[0])
         self.assertNotIn("special_task", violations[0])
-
-    def test_with_actual_yaml(self):
-
-        yaml_path = "/home/ubuntu/mongo/etc/evaluated_evergreen.yml"
-        with open(yaml_path, 'r') as file:
-            yaml_content = yaml.safe_load(file)
-
-        rule_config = {
-            "task_experimental_tag": "experimental",
-            "variant_no_experimental_tag": "no_task_tag_experimental",
-            "ignored_tasks": [
-              "search_end_to_end_single_node"
-            ]
-        }
-        violations = self.rule(rule_config, yaml_content)
-
-        for violation in violations:
-            print(violation)
-
-        self.assertTrue(len(violations) > 0, "Expected at least one violation")
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
# Prevent Experimental Tasks in Non-Experimental Variants Linter

This new linter rule prevents experimental tasks from being used in non-experimental buildvariants. 

1. Flags violations where tasks with the "experimental" tag are used in buildvariants with the "no_task_tag_experimental" tag.
2. Allows for specific tasks to be included even if they are experimental and in non-experimental build variants (to have back door for search_end_to_end_sharded_cluster and search_end_to_end_single_node or similar case in the future)

Examples on how to use it: 
**task_experimental_tag**: Tasks with this tag are considered experimental and should not be run in non-experimental variants.
**variant_no_experimental_tag**: Variants with this tag are considered non experimental build variants and should only use our tagging structure like(.development_critical .release_critical and etc)
**ignored_tasks**: These tasks can be included in any variant without triggering a linter warning.

        rule_config = {
            "task_experimental_tag": "experimental",   
            "variant_no_experimental_tag": "no_task_tag_experimental",
            "ignored_tasks": ["special_task"]
        }
        
# Testing
Unittest
test_no_violations_when_experimental_tasks_in_appropriate_variants
test_violation_when_experimental_task_in_non_experimental_variant
test_multiple_violations_across_different_variants
test_ignored_tasks_are_not_reported_as_violations
Plus
I have tested the actual evaluated_evergreen.yml file with adding 'no_task_tag_experimental' to 'enterprise-amazon-linux2-arm64-all-feature-flags'  and got the result as expected 
code below( I have deleted in this PR because it's just for testing purpose)
    def test_with_actual_yaml(self):

        yaml_path = "/home/ubuntu/mongo/etc/evaluated_evergreen.yml"
        with open(yaml_path, 'r') as file:
            yaml_content = yaml.safe_load(file)

        rule_config = {
            "task_experimental_tag": "experimental",
            "variant_no_experimental_tag": "no_task_tag_experimental",
            "ignored_tasks": [
              "search_end_to_end_single_node"
            ]
        }
        violations = self.rule(rule_config, yaml_content)

        for violation in violations:
            print(violation)

![image](https://github.com/user-attachments/assets/7755b455-6df0-4621-b66e-1eef332a9afb)
